### PR TITLE
增加文档Readme中安装faultInjectionLLM部分，并修复了action发版文件名的版本号固定的问题

### DIFF
--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -21,6 +21,14 @@ jobs:
         with:
           buildpackage-opts: --build=binary --no-sign
 
+      # 提取版本号（去掉 "v" 前缀）
+      - name: Extract version from tag
+        id: extract_version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "Extracted version: $VERSION"
+          echo "::set-output name=version::$VERSION"
+
       # 创建 GitHub Release
       - name: Create GitHub Release
         id: create_release
@@ -41,5 +49,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: debian/artifacts/faultinjectionllm_1.0.0_amd64.deb
-          asset_name: faultinjectionllm_1.0.0_amd64.deb
+          asset_name: faultinjectionllm_${{ steps.extract_version.outputs.version }}_amd64.deb
           asset_content_type: application/vnd.debian.binary-package

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ sudo apt install clang libc6-dev-i386 linux-headers-$(uname -r) python3.11-venv 
 sudo apt install build-essential flex bison dwarves libssl-dev libelf-dev libncurses-dev bc
 ```
 
+- 安装 faultInjectionLLM
+
+  前往[Github Releases](https://github.com/JiaHuann/Smart_Fault_Injector_LLM/releases), 下载最新 deb 文件。
+
+  安装 faultInjectionLLM, 将其中/path/to/faultinjectionllm_x.y.z_amd64.deb 换成你的路径和文件名
+  ```bash
+  sudo dpkg -i /path/to/faultinjectionllm_x.y.z_amd64.deb
+  ```
+
 ## 2.使用faultInjectionLLM
 0. 在仓库根目录创建`.env`文件,并根据实际情况填写。
 ```yaml


### PR DESCRIPTION
1. 增加文档Readme中安装faultInjectionLLM部分
    
2. 修复了action发版文件名的版本号固定的问题
    faultinjectionllm_1.0.0_amd64.deb --> faultinjectionllm_x.y.z_amd64.deb